### PR TITLE
Update NugetCommand to push to nuget.org and prevent releases on manual runs of the branches

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -1,4 +1,4 @@
-trigger:
+﻿trigger:
   branches:
     include:
     - master
@@ -17,6 +17,8 @@ variables:
   value: Packages
 - name: SolutionFileName # Example: MyApplication.sln
   value: DataLoader.sln
+- name: IsReleaseBranch # Should this branch name use the release stage
+  value: or(eq(variables['Build.SourceBranchName'], 'master'), startsWith(variables['Build.SourceBranchName'], 'feature/'), startsWith(variables['Build.SourceBranchName'], 'release/'))
 
 stages:
 - stage: Build
@@ -46,8 +48,8 @@ stages:
     - template: stage-build.yml
 
 - stage: Release
-  # Only release when the build is not for a Pull Request.
-  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  # Only release when the build is not for a Pull Request and branch name fits
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['IsReleaseBranch'], 'true'))
   jobs:
   - job: Publish_NuGet_Internal
 

--- a/build/stage-release.yml
+++ b/build/stage-release.yml
@@ -14,11 +14,12 @@
     checkLatest: false
 
 - task: NuGetCommand@2
+  displayName: 'Push to Nuget.org'
   inputs:
     command: 'push'
     packagesToPush: '$(Build.ArtifactStagingDirectory)/$(ArtifactName)/*.nupkg'
-    nuGetFeedType: 'internal'
-    publishVstsFeed: 'nventive'
+    nuGetFeedType: 'external'
+    publishVstsFeed: 'NuGet.org - nventive'
 
 - task: PostBuildCleanup@3
   displayName: 'Post-Build cleanup :  Cleanup files to keep build server clean!'


### PR DESCRIPTION
## Proposed Changes
- Build or CI related changes

## What is the new behavior?
Update NugetCommand to push to nuget.org and prevent releases on manual runs of the branches


## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [X] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue