### PR TITLE
Remove the IDictionary implementation from IDataLoaderContext to fix XAML binding issues. Simplify test namespaces.

### DIFF
--- a/src/DataLoader.Abstractions/IDataLoaderContext.cs
+++ b/src/DataLoader.Abstractions/IDataLoaderContext.cs
@@ -7,26 +7,46 @@ namespace Chinook.DataLoader
 	/// <summary>
 	/// A <see cref="IDataLoaderContext"/> represents metadata added to the <see cref="IDataLoaderRequest"/> before and during its execution.
 	/// </summary>
-	public interface IDataLoaderContext : IDictionary<string, object>
+	/// <remarks>
+	/// We don't implement <see cref="IReadOnlyDictionary{TKey, TValue}"/> because the xaml binding engine has a special behavior for types implementing this interface.
+	/// The xaml engine uses <see cref="IReadOnlyDictionary{TKey, TValue}.ContainsKey(TKey)"/> instead of the indexer, which we don't want.
+	/// </remarks>
+	public interface IDataLoaderContext : IEnumerable<KeyValuePair<string, object>>
 	{
+		/// <inheritdoc cref="IDictionary{TKey, TValue}.Add"/>
+		void Add(string key, object value);
+
+		/// <inheritdoc cref="IDictionary{TKey, TValue}.Remove(TKey)"/>
+		bool Remove(string key);
+
+		/// <summary>
+		/// The count of items in the <see cref="IDataLoaderContext"/>.
+		/// </summary>
+		int Count { get; }
+
 		/// <summary>
 		/// Gets or sets a value for the given key.
 		/// If the key is not found, null is returned.
 		/// </summary>
 		/// <param name="key">Key</param>
 		/// <returns>The value associated to the key when available; null otherwise.</returns>
-		new object this[string key] { get; set; }
+		object this[string key] { get; set; }
 
 		/// <inheritdoc cref="IReadOnlyDictionary{TKey, TValue}.Keys"/>
-		/// <remarks>
-		/// We hide <see cref="IDictionary{TKey, TValue}.Keys"/> because it's mutable and we want an immutable collection of keys.
-		/// </remarks>
-		new IEnumerable<string> Keys { get; }
+		IEnumerable<string> Keys { get; }
 
 		/// <inheritdoc cref="IReadOnlyDictionary{TKey, TValue}.Values"/>
-		/// <remarks>
-		/// We hide <see cref="IDictionary{TKey, TValue}.Values"/> because it's mutable and we want an immutable collection of values.
-		/// </remarks>
-		new IEnumerable<object> Values { get; }
+		IEnumerable<object> Values { get; }
+
+		/// <inheritdoc cref="IReadOnlyDictionary{TKey, TValue}.ContainsKey(TKey)"/>
+		bool ContainsKey(string key);
+
+		/// <inheritdoc cref="IReadOnlyDictionary{TKey, TValue}.TryGetValue(TKey, out TValue)"/>
+		bool TryGetValue(string key, out object value);
+
+		/// <summary>
+		/// Removes all items from the <see cref="IDataLoaderContext"/>.
+		/// </summary>
+		void Clear();
 	}
 }

--- a/src/DataLoader.Tests/Core/Integration/DisposeWithNextLoadTests.cs
+++ b/src/DataLoader.Tests/Core/Integration/DisposeWithNextLoadTests.cs
@@ -4,9 +4,10 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Chinook.DataLoader;
 using Xunit;
 
-namespace Chinook.DataLoader.Tests.Core.Integration
+namespace Tests.Core.Integration
 {
 	public class DisposeWithNextLoadTests
 	{

--- a/src/DataLoader.Tests/Core/Integration/SubscribeToDataTests.cs
+++ b/src/DataLoader.Tests/Core/Integration/SubscribeToDataTests.cs
@@ -4,10 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Chinook.DataLoader;
 using Chinook.DataLoader.SubscribeToData;
 using Xunit;
 
-namespace Chinook.DataLoader.Tests.Core.Integration
+namespace Tests.Core.Integration
 {
 	public class SubscribeToDataTests
 	{

--- a/src/DataLoader.Tests/Core/Unit/DataLoaderBuilderTests.cs
+++ b/src/DataLoader.Tests/Core/Unit/DataLoaderBuilderTests.cs
@@ -3,9 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Chinook.DataLoader;
 using Xunit;
 
-namespace Chinook.DataLoader.Tests.Core.Unit
+namespace Tests.Core.Unit
 {
 	public class DataLoaderBuilderTests
 	{

--- a/src/DataLoader.Tests/DataLoader.Tests.csproj
+++ b/src/DataLoader.Tests/DataLoader.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
 		<AssemblyName>Chinook.DataLoader.Tests</AssemblyName>
-    <RootNamespace>Chinook.DataLoader.Tests</RootNamespace>
+    <RootNamespace>Tests</RootNamespace>
 		<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/src/DataLoader.Tests/DynamicMvvm/Integration/ViewModelTests.cs
+++ b/src/DataLoader.Tests/DynamicMvvm/Integration/ViewModelTests.cs
@@ -12,7 +12,7 @@ using Xunit.Abstractions;
 using Xunit.Extensions;
 using Xunit.Sdk;
 
-namespace Chinook.DataLoader.Tests
+namespace Tests.DynamicMvvm.Integration
 {
 	public class ViewModelTests
 	{

--- a/src/DataLoader/DataLoaderContext.cs
+++ b/src/DataLoader/DataLoaderContext.cs
@@ -35,29 +35,15 @@ namespace Chinook.DataLoader
 
 		public int Count => _values.Count;
 
-		public bool IsReadOnly => _values.IsReadOnly;
-
-		ICollection<string> IDictionary<string, object>.Keys => _values.Keys;
-
-		ICollection<object> IDictionary<string, object>.Values => _values.Values;
-
 		public void Add(string key, object value) => _values.Add(key, value);
-
-		public void Add(KeyValuePair<string, object> item) => _values.Add(item);
 
 		public void Clear() => _values.Clear();
 
-		public bool Contains(KeyValuePair<string, object> item) => _values.Contains(item);
-
 		public bool ContainsKey(string key) => _values.ContainsKey(key);
-
-		public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex) => _values.CopyTo(array, arrayIndex);
 
 		public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => _values.GetEnumerator();
 
 		public bool Remove(string key) => _values.Remove(key);
-
-		public bool Remove(KeyValuePair<string, object> item) => _values.Remove(item);
 
 		public bool TryGetValue(string key, out object value) => _values.TryGetValue(key, out value);
 

--- a/src/DataLoader/DataLoaderRequest.cs
+++ b/src/DataLoader/DataLoaderRequest.cs
@@ -7,6 +7,7 @@ namespace Chinook.DataLoader
 	/// <summary>
 	/// This is a default implementation of <see cref="IDataLoaderRequest"/>.
 	/// </summary>
+	[Preserve(AllMembers = true)]
 	public class DataLoaderRequest : IDataLoaderRequest
 	{
 		/// <summary>

--- a/src/DataLoader/MergedDataLoaderContext.cs
+++ b/src/DataLoader/MergedDataLoaderContext.cs
@@ -46,29 +46,15 @@ namespace Chinook.DataLoader
 
 		public int Count => _mergedValues.Count;
 
-		public bool IsReadOnly => _loaderValues.IsReadOnly;
-
-		ICollection<string> IDictionary<string, object>.Keys => _loaderValues.Keys;
-
-		ICollection<object> IDictionary<string, object>.Values => _loaderValues.Values;
-
 		public void Add(string key, object value) => _loaderValues.Add(key, value);
-
-		public void Add(KeyValuePair<string, object> item) => _loaderValues.Add(item);
 
 		public void Clear() => _loaderValues.Clear();
 
-		public bool Contains(KeyValuePair<string, object> item) => _mergedValues.Contains(item);
-
 		public bool ContainsKey(string key) => _mergedValues.ContainsKey(key);
-
-		public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex) => throw new NotSupportedException($"{nameof(CopyTo)} is not supported on {nameof(MergedDataLoaderContext)}.");
 
 		public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => _mergedValues.GetEnumerator();
 
 		public bool Remove(string key) => _loaderValues.Remove(key);
-
-		public bool Remove(KeyValuePair<string, object> item) => _loaderValues.Remove(item);
 
 		public bool TryGetValue(string key, out object value) => _mergedValues.TryGetValue(key, out value);
 


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

XAML Binding errors on IDataLoaderContext

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

No more XAML Binding errors on IDataLoaderContext

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

