### PR TITLE
feat: Add support for strongly typed derivatives of DataLoaderView

### DIFF
--- a/src/DataLoader.Uno/DataLoaderView.cs
+++ b/src/DataLoader.Uno/DataLoaderView.cs
@@ -236,7 +236,7 @@ namespace Chinook.DataLoader
 		{
 			var safeState = newState ?? DataLoaderState.Default;
 
-			State = CreateDataLoaderViewState(safeState);
+			SetState(CreateDataLoaderViewState(safeState));
 
 			var dataVisualState = GetDataVisualState(safeState);
 			GoToState(DataVisualGroup, dataVisualState);
@@ -273,6 +273,18 @@ namespace Chinook.DataLoader
 					_logger.LogTrace($"Saved VisualStates to '{combinedVisualState}'. (This control isn't loaded yet.)");
 				}
 			}
+		}
+
+		/// <summary>
+		/// Sets the <see cref="State"/>.
+		/// </summary>
+		/// <remarks>
+		/// This method is virtual to allow creation of more strongly typed version of DataLoaderView to allow usage of x:Bind inside the ContentTemplate.
+		/// </remarks>
+		/// <param name="state">The <see cref="DataLoaderViewState"/> to set as the current state.</param>
+		protected virtual void SetState(DataLoaderViewState state)
+		{
+			State = state;
 		}
 
 		/// <summary>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

`DataLoaderView`.State is always set to a `DataLoaderViewState` object;

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

Classes derived from `DataLoaderView` can now used derivatives of `DataLoaderViewState`.
This enables `x:Bind` scenarios inside the DataLoaderView's ContentTemplate by using strongly typed derivatives.

In the following example, I used specialized versions of `DataLoaderView` and `DataLoaderViewState` that allow me to use `x:Bind` and benefit from IntelliSense in XAML.
![image](https://user-images.githubusercontent.com/39710855/122652657-e1529d80-d10d-11eb-908e-24e4c6755c9a.png)


## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

