### PR TITLE
feat: Add options to DynamicCommandDataLoaderTrigger

### DIFF
--- a/src/DataLoader.Tests/DynamicMvvm/Unit/DynamicCommandDataLoaderTriggerTests.cs
+++ b/src/DataLoader.Tests/DynamicMvvm/Unit/DynamicCommandDataLoaderTriggerTests.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Chinook.DataLoader;
+using Chinook.DynamicMvvm;
+using FluentAssertions;
+using Xunit;
+
+namespace Tests.DynamicMvvm.Unit
+{
+	public class DynamicCommandDataLoaderTriggerTests
+	{
+		[Fact]
+		private void Triggers_before_execution()
+		{
+			var command = new TestCommand();
+			var sut = new DynamicCommandDataLoaderTrigger(command, CommandTriggerOptions.TriggerBeforeCommandExecution);
+			int loadRequests = 0;
+
+			sut.LoadRequested += OnLoadRequested;
+
+			loadRequests.Should().Be(0);
+			command.IsExecuting = true;
+			loadRequests.Should().Be(1);
+			command.IsExecuting = false;
+			loadRequests.Should().Be(1);
+
+			void OnLoadRequested(IDataLoaderTrigger trigger, IDataLoaderContext context)
+			{
+				++loadRequests;
+			}
+		}
+
+		[Fact]
+		private void Triggers_after_execution()
+		{
+			var command = new TestCommand();
+			var sut = new DynamicCommandDataLoaderTrigger(command, CommandTriggerOptions.TriggerAfterCommandExecution);
+			int loadRequests = 0;
+
+			sut.LoadRequested += OnLoadRequested;
+
+			loadRequests.Should().Be(0);
+			command.IsExecuting = true;
+			loadRequests.Should().Be(0);
+			command.IsExecuting = false;
+			loadRequests.Should().Be(1);
+
+			void OnLoadRequested(IDataLoaderTrigger trigger, IDataLoaderContext context)
+			{
+				++loadRequests;
+			}
+		}
+
+		[Fact]
+		private void Triggers_before_and_after_execution()
+		{
+			var command = new TestCommand();
+			var sut = new DynamicCommandDataLoaderTrigger(command, CommandTriggerOptions.TriggerBeforeCommandExecution | CommandTriggerOptions.TriggerAfterCommandExecution);
+			int loadRequests = 0;
+
+			sut.LoadRequested += OnLoadRequested;
+
+			loadRequests.Should().Be(0);
+			command.IsExecuting = true;
+			loadRequests.Should().Be(1);
+			command.IsExecuting = false;
+			loadRequests.Should().Be(2);
+
+			void OnLoadRequested(IDataLoaderTrigger trigger, IDataLoaderContext context)
+			{
+				++loadRequests;
+			}
+		}
+
+		private class TestCommand : IDynamicCommand
+		{
+			public string Name => "Test";
+
+			private bool _isExecuting;
+			public bool IsExecuting
+			{
+				get => _isExecuting;
+				set
+				{
+					_isExecuting = value;
+					IsExecutingChanged?.Invoke(this, null);
+				}
+			}
+
+			public event EventHandler IsExecutingChanged;
+			public event EventHandler CanExecuteChanged;
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			public bool CanExecute(object parameter)
+			{
+				throw new NotImplementedException();
+			}
+
+			public void Dispose()
+			{
+				throw new NotImplementedException();
+			}
+
+			public Task Execute(object parameter)
+			{
+				throw new NotImplementedException();
+			}
+
+			void ICommand.Execute(object parameter)
+			{
+				throw new NotImplementedException();
+			}
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue: #24
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

It's not possible to specify an after-the-command-execution trigger.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

`DynamicCommandDataLoaderTrigger` now supports `CommandTriggerOptions.TriggerBeforeCommandExecution` and `CommandTriggerOptions.TriggerAfterCommandExecution` as enum flags.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [x] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

