### PR TITLE
Dev/jpl/leak fix

### DIFF
--- a/src/DataLoader.Uno/DataLoaderView.cs
+++ b/src/DataLoader.Uno/DataLoaderView.cs
@@ -51,6 +51,7 @@ namespace Chinook.DataLoader
 		private IDataLoaderState _lastState;
 		private DataLoaderViewState _lastViewState;
 		private bool _isLoaded;
+		private bool _isSubscribedToSource;
 		private bool _isVisualStateRefreshRequired;
 		private DateTimeOffset _lastUpdate = DateTimeOffset.MinValue; // This is a timestamp of when the last UI update was done.
 		private TimeSpan _stateMinDuration = TimeSpan.Zero; // This is the non-"UI thread dependent" version of StateMinimumDuration.
@@ -65,7 +66,7 @@ namespace Chinook.DataLoader
 
 			Loaded += OnLoaded;
 			Unloaded += OnUnloaded;
-		}		
+		}
 
 		protected override void OnApplyTemplate()
 		{
@@ -76,12 +77,24 @@ namespace Chinook.DataLoader
 
 		private void OnLoaded(object sender, RoutedEventArgs e)
 		{
+			if (!_isSubscribedToSource && _dataLoader != null)
+			{
+				_dataLoader.StateChanged += OnDataLoaderStateChanged;
+				_isSubscribedToSource = true;
+			}
+
 			_isLoaded = true;
 			Update(_dataLoader?.State);
 		}
 
 		private void OnUnloaded(object sender, RoutedEventArgs e)
 		{
+			if (_dataLoader != null)
+			{
+				_dataLoader.StateChanged -= OnDataLoaderStateChanged;
+				_isSubscribedToSource = false;
+			}
+
 			_isLoaded = false;
 		}
 
@@ -90,6 +103,7 @@ namespace Chinook.DataLoader
 			if (_dataLoader != null)
 			{
 				_dataLoader.StateChanged -= OnDataLoaderStateChanged;
+				_isSubscribedToSource = false;
 			}
 
 			_dataLoader = dataLoader;
@@ -99,6 +113,7 @@ namespace Chinook.DataLoader
 			if (dataLoader != null)
 			{
 				_dataLoader.StateChanged += OnDataLoaderStateChanged;
+				_isSubscribedToSource = true;
 
 				if (AutoLoad)
 				{

--- a/src/DataLoader.Uno/DataLoaderViewState.cs
+++ b/src/DataLoader.Uno/DataLoaderViewState.cs
@@ -9,6 +9,22 @@ namespace Chinook.DataLoader
 	[Bindable]
 	public class DataLoaderViewState
 	{
+		// Here we use WeakReference on all reference types because UWP creates "Dependent Handles" on DataLoaderViewState instances, preventing GC.
+		// There isn't much information about how to investigate dependent handles so this solution might not be the one.
+
+		// Note that even though we use WeakReferences, we shouldn't get any unwanted GC.
+		// View is strongly held by its UI tree parent. Once the DataLoaderView lost, the DataLoaderViewState shouldn't be used anyways.
+		// Parent (DataLoaderView's DataContext) is strongly held by the DataLoaderView.
+		// Source is also strongly held by the DataLoaderView.
+		// Request, Data, and Error are all strongly held by the DataLoader's State (strongly held in DataLoaderView's Source).
+
+		private WeakReference<DataLoaderView> _view = new WeakReference<DataLoaderView>(null);
+		private WeakReference<object> _parent = new WeakReference<object>(null);
+		private WeakReference<IDataLoader> _source = new WeakReference<IDataLoader>(null);
+		private WeakReference<IDataLoaderRequest> _request = new WeakReference<IDataLoaderRequest>(null);
+		private WeakReference<object> _data = new WeakReference<object>(null);
+		private WeakReference<Exception> _error = new WeakReference<Exception>(null);
+
 		/// <summary>
 		/// Creates a new instance of <see cref="DataLoaderViewState"/>.
 		/// </summary>
@@ -36,17 +52,41 @@ namespace Chinook.DataLoader
 			IsEmpty = dataLoaderViewState.IsEmpty;
 		}
 
-		public DataLoaderView View { get; set; }
+		public DataLoaderView View
+		{
+			get => _view.GetTargetOrDefault();
+			set => _view.SetTarget(value);
+		}
 
-		public object Parent { get; set; }
+		public object Parent
+		{
+			get => _parent.GetTargetOrDefault();
+			set => _parent.SetTarget(value);
+		}
 
-		public IDataLoader Source { get; set; }
+		public IDataLoader Source
+		{
+			get => _source.GetTargetOrDefault();
+			set => _source.SetTarget(value);
+		}
 
-		public IDataLoaderRequest Request { get; set; }
+		public IDataLoaderRequest Request
+		{
+			get => _request.GetTargetOrDefault();
+			set => _data.SetTarget(value);
+		}
 
-		public object Data { get; set; }
+		public object Data
+		{
+			get => _data.GetTargetOrDefault();
+			set => _data.SetTarget(value);
+		}
 
-		public Exception Error { get; set; }
+		public Exception Error
+		{
+			get => _error.GetTargetOrDefault();
+			set => _error.SetTarget(value);
+		}
 
 		public bool IsLoading { get; set; }
 

--- a/src/DataLoader.Uno/WeakReference.Extensions.cs
+++ b/src/DataLoader.Uno/WeakReference.Extensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Chinook.DataLoader
+{
+	internal static class WeakReference
+	{
+		public static T GetTargetOrDefault<T>(this WeakReference<T> weakReference)
+			where T : class
+		{
+			return weakReference.TryGetTarget(out var value) ? value : default(T);
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

- Objects referenced by `DataLoaderViewState` are sometimes prevented from GC because of Dependent Handle.
- `IDataLoader.StateChanged` is not unsubscribed from when `DataLoaderView` unloads.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

- `DataLoaderViewState` uses `WeakReference` for each of its object reference.
- `IDataLoader.StateChanged` is unsubscribed from when `DataLoaderView` unloads (and re-subscribed to when it loads).

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

