### PR TITLE
fix: Fix invalid cast exception when using WithTrigger.

### DIFF
--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.3.0
+next-version: 0.4.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/DataLoader.Abstractions/IDataLoaderBuilder.Extensions.cs
+++ b/src/DataLoader.Abstractions/IDataLoaderBuilder.Extensions.cs
@@ -67,22 +67,7 @@ namespace Chinook.DataLoader
 			return builder;
 		}
 
-		/// <summary>
-		/// Adds a <see cref="IDataLoaderTrigger"/> in <see cref="IDataLoaderBuilder.TriggerProviders"/>.
-		/// </summary>
-		/// <typeparam name="TData">The type of data.</typeparam>
-		/// <param name="builder">The <see cref="IDataLoaderBuilder"/> reference.</param>
-		/// <param name="triggerProvider">The new <see cref="IDataLoaderTrigger"/> to add.</param>
-		public static IDataLoaderBuilder<TData> WithTrigger<TData>(this IDataLoaderBuilder<TData> builder, Func<IDataLoader<TData>, IDataLoaderTrigger> triggerProvider)
-		{
-			builder.TriggerProviders.Add(GetTriggerProvider);
-			return builder;
-
-			IDataLoaderTrigger GetTriggerProvider(IDataLoader dataLoader)
-			{
-				return triggerProvider((IDataLoader<TData>)dataLoader);
-			}
-		}
+		
 
 		/// <summary>
 		/// Adds a <see cref="IDataLoaderTrigger"/> in <see cref="IDataLoaderBuilder.TriggerProviders"/>.

--- a/src/DataLoader.Tests/Core/Integration/WithTriggerTests.cs
+++ b/src/DataLoader.Tests/Core/Integration/WithTriggerTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Chinook.DataLoader;
+using FluentAssertions;
+using Xunit;
+
+namespace Tests.Core.Integration
+{
+	public class WithTriggerTests
+	{
+		[Fact]
+		public async Task WithTrigger_should_type_the_DataLoader_parameter_correctly()
+		{
+			var addedTrigger = false;
+			var dataLoader = DataLoaderBuilder<string>
+				.Empty
+				.WithName("Test")
+				.WithLoadMethod(async (ct, request) => "data")
+				.WithTrigger(typedDataLoader =>
+				{
+					typedDataLoader.Should().NotBeNull();
+					typedDataLoader.Should().BeAssignableTo<IDataLoader<string>>();
+					addedTrigger = true;
+					return new ManualDataLoaderTrigger();
+				})
+				.Build();
+
+			addedTrigger.Should().BeTrue();
+		}
+	}
+}

--- a/src/DataLoader.Tests/Core/Unit/DataLoaderBuilderTests.cs
+++ b/src/DataLoader.Tests/Core/Unit/DataLoaderBuilderTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Chinook.DataLoader;
+using FluentAssertions;
 using Xunit;
 
 namespace Tests.Core.Unit
@@ -26,7 +27,7 @@ namespace Tests.Core.Unit
 			builder = builder.WithTrigger(d => new ManualDataLoaderTrigger());
 			builder = builder.WithTrigger(new ManualDataLoaderTrigger());
 
-			Assert.NotNull(builder);
+			builder.Should().NotBeNull();
 		}
 
 		/// <summary>
@@ -45,7 +46,7 @@ namespace Tests.Core.Unit
 			builder = builder.WithTrigger(d => new ManualDataLoaderTrigger());
 			builder = builder.WithTrigger(new ManualDataLoaderTrigger());
 
-			Assert.NotNull(builder);
+			builder.Should().NotBeNull();
 		}
 
 		/// <summary>
@@ -64,7 +65,7 @@ namespace Tests.Core.Unit
 				.WithTrigger(d => new ManualDataLoaderTrigger())
 				.WithTrigger(new ManualDataLoaderTrigger());
 
-			Assert.NotNull(builder);
+			builder.Should().NotBeNull();
 		}
 
 		/// <summary>
@@ -83,7 +84,7 @@ namespace Tests.Core.Unit
 				.WithTrigger(d => new ManualDataLoaderTrigger())
 				.WithTrigger(new ManualDataLoaderTrigger());
 
-			Assert.NotNull(builder);
+			builder.Should().NotBeNull();
 		}
 	}
 }

--- a/src/DataLoader/Extensions/IDataLoader.Extensions.cs
+++ b/src/DataLoader/Extensions/IDataLoader.Extensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Chinook.DataLoader
+{
+	/// <summary>
+	/// Extensions on <see cref="IDataLoader"/>.
+	/// </summary>
+	public static class DataLoaderExtensions
+	{
+		/// <summary>
+		/// Returns a typed version of <see cref="IDataLoader"/>.
+		/// </summary>
+		/// <typeparam name="TData">The type of data.</typeparam>
+		/// <param name="dataLoader">The <see cref="IDataLoader"/>.</param>
+		/// <returns><see cref="IDataLoaderState{TData}"/>.</returns>
+		public static IDataLoader<TData> AsOf<TData>(this IDataLoader dataLoader)
+		{
+			if (dataLoader is IDataLoader<TData> typedDataLoader)
+			{
+				return typedDataLoader;
+			}
+			else
+			{
+				return new TypedDataLoaderDecorator<TData>(dataLoader);
+			}
+		}
+	}
+}

--- a/src/DataLoader/Extensions/IDataLoaderBuilder.Extensions.cs
+++ b/src/DataLoader/Extensions/IDataLoaderBuilder.Extensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Chinook.DataLoader
+{
+	/// <summary>
+	/// Extensions on <see cref="IDataLoaderBuilder"/>.
+	/// </summary>
+	public static class DataLoaderBuilderExtensions2
+	{
+		/// <summary>
+		/// Adds a <see cref="IDataLoaderTrigger"/> in <see cref="IDataLoaderBuilder.TriggerProviders"/>.
+		/// </summary>
+		/// <typeparam name="TData">The type of data.</typeparam>
+		/// <param name="builder">The <see cref="IDataLoaderBuilder"/> reference.</param>
+		/// <param name="triggerProvider">The new <see cref="IDataLoaderTrigger"/> to add.</param>
+		public static IDataLoaderBuilder<TData> WithTrigger<TData>(this IDataLoaderBuilder<TData> builder, Func<IDataLoader<TData>, IDataLoaderTrigger> triggerProvider)
+		{
+			builder.TriggerProviders.Add(GetTriggerProvider);
+			return builder;
+
+			IDataLoaderTrigger GetTriggerProvider(IDataLoader dataLoader)
+			{				
+				return triggerProvider(dataLoader.AsOf<TData>());				
+			}
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

- You can an invalid cast exception when using the following overload of `WithTrigger`.
```csharp
public static IDataLoaderBuilder<TData> WithTrigger<TData>(this IDataLoaderBuilder<TData> builder, Func<IDataLoader<TData>, IDataLoaderTrigger> triggerProvider)
```

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

The extension method now works properly.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Version was bumped because of breaking change.
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

