### PR TITLE
feat: Support Android 12 and build on VS2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Support for Android 11 (March, 2021)
 
 ### Changed
+* Build with VS2022
+* Add support for uap10.0.19041
+* Add support for Android 12
+* Dropped support for uap10.0.18362
+* Dropped support for MonoAndroid10 target
 [#24] Update Android target to 10.0
 [#33] Change target Uno.UI version to 4.0.7
 ### Deprecated

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -7,13 +7,13 @@
 resources:
    containers:
      - container: windows
-       image: nventive/vs_build-tools:16.8.6
+       image: nventive/vs_build-tools:17.1.1
 
 variables:
 - name: NUGET_VERSION
-  value: 5.4.0
+  value: 6.1.0
 - name: VSTEST_PLATFORM_VERSION
-  value: 15.9.2
+  value: 17.1.1
 - name: ArtifactName
   value: Packages
 - name: SolutionFileName # Example: MyApplication.sln
@@ -22,7 +22,7 @@ variables:
   value: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
 # Pool names
 - name: windowsPoolName
-  value: 'windows 1809'
+  value: 'windows 2022'
 
 stages:
 - stage: Build

--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.5.0
+next-version: 0.6.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/DataLoader.DynamicMvvm/DataLoader.DynamicMvvm.csproj
+++ b/src/DataLoader.DynamicMvvm/DataLoader.DynamicMvvm.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Chinook.DynamicMvvm.Abstractions" Version="0.7.0-dev.67" />
+        <PackageReference Include="Chinook.DynamicMvvm.Abstractions" Version="0.9.0-dev.85" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/DataLoader.Tests/DataLoader.Tests.csproj
+++ b/src/DataLoader.Tests/DataLoader.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-		<PackageReference Include="Chinook.DynamicMvvm" Version="0.7.0-dev.67" />
+		<PackageReference Include="Chinook.DynamicMvvm" Version="0.9.0-dev.85" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DataLoader.Uno/DataLoader.Uno.csproj
+++ b/src/DataLoader.Uno/DataLoader.Uno.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<!-- Change the TargetFrameworks depending on which platform you are building on. This avoids errors as it is impossible to build UAP on OSX (MacOS) -->
 		<TargetFrameworks Condition="'$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;</TargetFrameworks>
-		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid10.0;monoandroid11.0;uap10.0.18362</TargetFrameworks>
+		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid11.0;monoandroid12.0;uap10.0.19041</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<RootNamespace>Chinook.DataLoader</RootNamespace>
@@ -18,7 +18,7 @@
 		<DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
 	</PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid10.0' or '$(TargetFramework)'=='monoandroid11.0' or '$(TargetFramework)'=='netstandard2.0'">
+	<ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid11.0' or '$(TargetFramework)'=='monoandroid12.0' or '$(TargetFramework)'=='netstandard2.0'">
 		<PackageReference Include="Uno.UI" Version="4.0.7" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>


### PR DESCRIPTION
GitHub Issue: #N/A

## Proposed Changes
Support Android 12 and build on VS2022

Feature
Build or CI related changes
Documentation content changes


## What is the current behavior?
Does not support Android 12 and build on VS2022


## What is the new behavior?
Supports Android 12 and build on VS2022


## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

Since all new projects will need to target Android 12, it is not needed to target Android 10 anymore


## Other information
