### PR TITLE
feat: Add IViewModel.GetFromDataLoaderState extension method

### DIFF
--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -1,6 +1,6 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
-next-version: 0.6.0
+next-version: 0.7.0
 continuous-delivery-fallback-tag: ""
 increment: none # Disabled as it is not used. Saves time on the GitVersion step
 branches:

--- a/src/DataLoader.DynamicMvvm/IViewModelExtensions.Commands.cs
+++ b/src/DataLoader.DynamicMvvm/IViewModelExtensions.Commands.cs
@@ -9,10 +9,7 @@ using Chinook.DataLoader;
 
 namespace Chinook.DynamicMvvm
 {
-	/// <summary>
-	/// Extensions on <see cref="IViewModel"/> to create commands for <see cref="IDataLoader"/>.
-	/// </summary>
-	public static partial class IViewModelExtensions
+	public static partial class DataLoaderViewModelExtensions
 	{
 		/// <summary>
 		/// Gets or creates a <see cref="IDynamicCommand"/> that will refresh

--- a/src/DataLoader/AssemblyInfo.cs
+++ b/src/DataLoader/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Chinook.DataLoader.Uno")]
+[assembly: InternalsVisibleTo("Chinook.DataLoader.DynamicMvvm")]
 [assembly: InternalsVisibleTo("Chinook.DataLoader.Tests")]


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature

## Description
- Rename `IViewModelExtensions` to `DataLoaderViewModelExtensions` to be more specific.
  - This is a binary breaking change, but should not have much impact.
- Add extension `IViewModel.GetFromDataLoaderState` so that view models can have dynamic properties bound to a dataloader's state.

```csharp
public IDataLoaderState<string[]> TitlesState => this.GetFromDataLoaderState(Titles);

public IDataLoader<string[]> Titles => this.GetDataLoader(GetTitles, b => b
	.OnBackgroundThread()
	.WithName("MySuperTitles")
	.WithEmptySelector(d => !(d.Data?.Any() ?? false))
);
```

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

