### PR TITLE
feat: Add OnDataLostDataLoaderStrategy + tests

### DIFF
--- a/src/DataLoader.Tests/Core/Unit/OnDataLostDataLoaderStrategyTests.cs
+++ b/src/DataLoader.Tests/Core/Unit/OnDataLostDataLoaderStrategyTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Chinook.DataLoader;
+using FluentAssertions;
+using Xunit;
+
+namespace Tests.Core.Unit
+{
+	public class OnDataLostDataLoaderStrategyTests
+	{
+		[Fact]
+		public async Task NotDisposePreviousData_When_FirstLoad()
+		{
+			// Arrange
+			var methodCount = 0;
+			Action<object> mockAction = data => methodCount++;
+
+			var sut = new OnDataLostDataLoaderStrategy(mockAction);
+			sut.InnerStrategy = new MockDelegatingDataLoaderStrategy(() => Task.FromResult(new object()));
+
+			// Act
+			await sut.Load(CancellationToken.None, null);
+
+			// Assert
+			methodCount.Should().Be(0);
+		}
+
+		[Theory]
+		[ClassData(typeof(OnDataLostDataLoaderStrategyTestData))]
+		public async Task DisposePreviousData_If_LoadReturnsNewReference(object firstLoad, object secondLoad, int expectedMethodCount)
+		{
+			// Arrange
+			var methodCount = 0;
+			var isFirstLoad = true;
+			Action<object> mockAction = data => methodCount++;
+
+			var sut = new OnDataLostDataLoaderStrategy(mockAction);
+			sut.InnerStrategy = new MockDelegatingDataLoaderStrategy(() =>
+			{
+				var result = isFirstLoad ? firstLoad : secondLoad;
+				return Task.FromResult(result);
+			});
+			await sut.Load(CancellationToken.None, null);
+			isFirstLoad = false;
+
+			// Act
+			await sut.Load(CancellationToken.None, null);
+
+			// Assert
+			methodCount.Should().Be(expectedMethodCount);
+		}
+
+		public class MockDelegatingDataLoaderStrategy : DelegatingDataLoaderStrategy
+		{
+			private Func<Task<object>> _innerFunc;
+
+			public MockDelegatingDataLoaderStrategy(Func<Task<object>> innerFunc)
+			{
+				_innerFunc = innerFunc;
+			}
+
+			public override async Task<object> Load(CancellationToken ct, IDataLoaderRequest request)
+			{
+				return await _innerFunc();
+			}
+		}
+
+		public class OnDataLostDataLoaderStrategyTestData : IEnumerable<object[]>
+		{
+			public IEnumerator<object[]> GetEnumerator()
+			{
+				var list = new List<object[]>();
+
+				var value = new Random().Next(int.MaxValue);
+				var instance1 = new object();
+				var instance2 = new object();
+
+				list.Add(new object[] { instance1, instance2, 1 }); // Different reference, will call dispose.
+				list.Add(new object[] { instance1, instance1, 0 }); // Same reference, won't call dispose.
+				list.Add(new object[] { value, value, 1 }); // Same value, but will still call dispose.
+
+				return list.GetEnumerator();
+			}
+
+			IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+		}
+	}
+}

--- a/src/DataLoader/Strategies/OnDataLostDataLoaderStrategy.cs
+++ b/src/DataLoader/Strategies/OnDataLostDataLoaderStrategy.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Chinook.DataLoader
+{
+	/// <summary>
+	/// This class is a <see cref="DelegatingDataLoaderStrategy"/> that offers a callback when the previous data reference is lost when getting new data.
+	/// </summary>
+	public class OnDataLostDataLoaderStrategy : DelegatingDataLoaderStrategy
+	{
+		private readonly Action<object> _onPreviousDataLost;
+		private object _data;
+
+		/// <summary>
+		/// Creates a new instance of <see cref="OnDataLostDataLoaderStrategy"/>.
+		/// </summary>
+		/// <param name="onPreviousDataLost">The action to invoke when the previous data is lost.</param>
+		public OnDataLostDataLoaderStrategy(Action<object> onPreviousDataLost)
+		{
+			_onPreviousDataLost = onPreviousDataLost;
+		}
+
+		/// <inheritdoc/>
+		public override async Task<object> Load(CancellationToken ct, IDataLoaderRequest request)
+		{
+			var result = await base.Load(ct, request);
+
+			// We should not dispose the previous data if we load the same instance.
+			if (_data != null && !ReferenceEquals(_data, result))
+			{
+				_onPreviousDataLost(_data);
+			}
+			_data = result;
+
+			return result;
+		}
+	}
+
+	/// <summary>
+	/// This class exposes extensions methods related to <see cref="OnDataLostDataLoaderStrategy"/>.
+	/// </summary>
+	public static class OnDataLostDataLoaderStrategyExtensions
+	{
+		/// <summary>
+		/// Adds a <see cref="OnDataLostDataLoaderStrategy"/> to this builder that will dispose the previous data when new data is received.
+		/// </summary>
+		/// <typeparam name="TBuilder">The type of the builder.</typeparam>
+		/// <param name="builder">The builder.</param>
+		/// <returns>The original builder.</returns>
+		public static TBuilder DisposePreviousData<TBuilder>(this TBuilder builder)
+			where TBuilder : IDataLoaderBuilder
+		{
+			return builder.WithStrategy(new OnDataLostDataLoaderStrategy(DisposeData));
+
+			void DisposeData(object data)
+			{
+				if (data is IDisposable disposable)
+				{
+					disposable.Dispose();
+				}
+				else if (data is IEnumerable enumerable)
+				{
+					foreach (var item in enumerable)
+					{
+						if (item is IDisposable disposableItem)
+						{
+							disposableItem.Dispose();
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature 

## Description
Add `OnDataLostDataLoaderStrategy`, a strategy that allows to do something when data from a `DataLoader `is lost (overridden by new data). A good use-case is dispose previous data when new data comes in.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

