### PR TITLE
fix: explicitly create a dynamicproperty with generic dataloaderstate

### DIFF
--- a/src/DataLoader.DynamicMvvm/IViewModelExtensions.DataLoader.cs
+++ b/src/DataLoader.DynamicMvvm/IViewModelExtensions.DataLoader.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -40,8 +39,16 @@ namespace Chinook.DynamicMvvm
 		{
 			return viewModel.GetOrCreateDynamicProperty(name, n =>
 			{
-				var initialState = isGeneric ? dataLoader.State.AsOf<TData>() : dataLoader.State;
-				var property = viewModel.GetDynamicPropertyFactory().Create(n, initialState, viewModel);
+				var property = default(IDynamicProperty);
+				if (isGeneric)
+				{
+					// We have to explicitly specify the type here, otherwise, it will instead use the non generic type (InvalidCastException).
+					property = viewModel.GetDynamicPropertyFactory().Create<IDataLoaderState<TData>>(n, dataLoader.State.AsOf<TData>(), viewModel);
+				}
+				else
+				{
+					property = viewModel.GetDynamicPropertyFactory().Create(n, dataLoader.State, viewModel);
+				}
 
 				dataLoader.StateChanged += OnStateChanged;
 


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

Bug fix

## What is the current behavior?
`GetFromDataLoaderState` with generic `IDataLoaderState` throw a `InvalidCastException`

## What is the new behavior?
`GetFromDataLoaderState` with generic `IDataLoaderState` do not throw any exception.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Documentation has been added/updated~~
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated~~
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the Changelog~~
- [ ] ~~Associated with an issue~~

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

