### PR TITLE
feat: Add support for default refresh commands in DataLoaderView.

### DIFF
--- a/src/DataLoader.Uno.Shared/DataLoaderView.Properties.cs
+++ b/src/DataLoader.Uno.Shared/DataLoaderView.Properties.cs
@@ -13,6 +13,23 @@ namespace Chinook.DataLoader
 	public partial class DataLoaderView
 	{
 		/// <summary>
+		/// Function used to populate the default value of the <see cref="RefreshCommand"/> property.
+		/// </summary>
+		/// <remarks>
+		/// This can be useful when most of your refresh commands have the same behavior for all instances of <see cref="DataLoaderView"/>.
+		/// </remarks>
+		public static Func<DataLoaderView, ICommand> DefaultRefreshCommandProvider { get; set; }
+
+		/// <summary>
+		/// Gets the <see cref="IDataLoader"/> associated to this control.
+		/// </summary>
+		/// <remarks>
+		/// This contains the same value as the <see cref="Source"/> property, but can be accessed from outside the control's dispatcher context.
+		/// This can be useful when using the <see cref="DefaultRefreshCommandProvider"/>.
+		/// </remarks>
+		public IDataLoader DataLoader { get; private set; }
+
+		/// <summary>
 		/// The <see cref="IDataLoader"/> driving the <see cref="DataLoaderView"/>.
 		/// </summary>
 		public IDataLoader Source
@@ -26,7 +43,10 @@ namespace Chinook.DataLoader
 
 		private static void OnSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
-			((DataLoaderView)d).OnSourceChanged((IDataLoader)e.NewValue);
+			var dataLoaderView = (DataLoaderView)d;
+			var dataLoader = (IDataLoader)e.NewValue;
+			dataLoaderView.DataLoader = dataLoader;
+			dataLoaderView.OnSourceChanged(dataLoader);
 		}
 
 		/// <summary>

--- a/src/DataLoader.Uno.Shared/DataLoaderView.cs
+++ b/src/DataLoader.Uno.Shared/DataLoaderView.cs
@@ -39,6 +39,8 @@ namespace Chinook.DataLoader
 			_controller = new DataLoaderViewController(this, Dispatcher);
 #endif
 
+			RefreshCommand = DefaultRefreshCommandProvider?.Invoke(this);
+
 			Loaded += OnLoaded;
 			Unloaded += OnUnloaded;
 		}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [x] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description
- It's now possible to define a command provider to auto-populate `DataLoaderView.RefreshCommand`­ with a default value.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [x] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [ ] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [ ] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

