### PR TITLE
fix: Ensure visual states are applied after OnApplyTemplate

### DIFF
--- a/src/DataLoader.Uno.Shared/DataLoaderView.cs
+++ b/src/DataLoader.Uno.Shared/DataLoaderView.cs
@@ -55,6 +55,13 @@ namespace Chinook.DataLoader
 			_controller.OnViewUnloaded();
 		}
 
+		protected override void OnApplyTemplate()
+		{
+			base.OnApplyTemplate();
+
+			_controller.OnControlTemplateApplied();
+		}
+
 		private void OnSourceChanged(IDataLoader dataLoader)
 		{
 			_controller.SetDataLoader(dataLoader);

--- a/src/DataLoader.Uno.Shared/DataLoaderViewControllerBase.cs
+++ b/src/DataLoader.Uno.Shared/DataLoaderViewControllerBase.cs
@@ -51,6 +51,7 @@ namespace Chinook.DataLoader
 		private IDataLoaderState _lastState;
 		private DataLoaderViewState _lastViewState;
 		private bool _isLoaded;
+		private bool _isControlTemplateApplied;
 		private bool _isSubscribedToSource;
 		private bool _isVisualStateRefreshRequired;
 		private DateTimeOffset _lastUpdate = DateTimeOffset.MinValue; // This is a timestamp of when the last UI update was done.
@@ -145,6 +146,12 @@ namespace Chinook.DataLoader
 			_isLoaded = false;
 		}
 
+		public void OnControlTemplateApplied()
+		{
+			_isControlTemplateApplied = true;
+			Update(_dataLoader?.State);
+		}
+
 		private void OnDataLoaderStateChanged(IDataLoader dataLoader, IDataLoaderState newState)
 		{
 			Update(newState);
@@ -190,7 +197,7 @@ namespace Chinook.DataLoader
 					if (Object.Equals(_nextState, _lastState))
 					{
 						// When the states are equal, we usually skip the update, unless a visual state refresh is required. (That happens when the DataLoader changes state before the DataLoaderView is Loaded.)
-						if (_isVisualStateRefreshRequired && _isLoaded)
+						if (_isVisualStateRefreshRequired && _isLoaded && _isControlTemplateApplied)
 						{
 							await RunOnDispatcher(() =>
 							{
@@ -288,7 +295,7 @@ namespace Chinook.DataLoader
 				var combinedVisualState = $"{dataVisualState}_{errorVisualState}_{loadingVisualState}";
 				GoToState(view, CombinedVisualGroup, combinedVisualState);
 
-				if (_isLoaded)
+				if (_isLoaded && _isControlTemplateApplied)
 				{
 					_isVisualStateRefreshRequired = false;
 
@@ -395,7 +402,7 @@ namespace Chinook.DataLoader
 				if (currentState != visualState)
 				{
 					_currentGroupStates[group] = visualState;
-					if (_isLoaded)
+					if (_isLoaded && _isControlTemplateApplied)
 					{
 						VisualStateManager.GoToState(control, visualState, useTransitions);
 					}
@@ -404,7 +411,7 @@ namespace Chinook.DataLoader
 			else
 			{
 				_currentGroupStates[group] = visualState;
-				if (_isLoaded)
+				if (_isLoaded && _isControlTemplateApplied)
 				{
 					VisualStateManager.GoToState(control, visualState, useTransitions);
 				}


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

When a DataLoaderView gets its data while being inside a collapsed container, making the container visible afterwards doesn't refresh the visual states of the DataLoaderView, resulting in its content not being visible until the next change in visual states.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

The DataLoaderView refreshes its visual states when the OnApplyTemplate method is called.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [x] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated Unit / Integration tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [ ] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

